### PR TITLE
Webdriver-manager added to 'requirements.txt'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ fpdf
 flask_bootstrap
 django
 email_validator
+webdriver-manager


### PR DESCRIPTION
As title states. Webdriver-manager is required to ensure the driver's PATH is found but wasn't apart of the original list of packages in 'requirements.txt'. It has been added.