### PR TITLE
Fixes to loginDriver.py and test1

### DIFF
--- a/tests/loginDriver.py
+++ b/tests/loginDriver.py
@@ -2,6 +2,7 @@ from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.by import By
+from signUpDriver import SignUp
 import time
 
 
@@ -9,7 +10,8 @@ class LogIn:
 
     def __init__(self):
 
-        self.driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()))
+        self.driver = webdriver.Chrome(
+            service=Service(ChromeDriverManager().install()))
 
     def login(self, username, password):
 
@@ -46,7 +48,8 @@ class LogIn:
         # 1 - failed login due to "user doesn't exist"
         self.login(username, password)
         alert1 = self.driver.\
-            find_element(By.XPATH, "//*[text()[contains(.,'user doesn')]]").text
+            find_element(
+                By.XPATH, "//*[text()[contains(.,'user doesn')]]").text
         LogIn.close(self)
         return alert1
 
@@ -54,9 +57,12 @@ class LogIn:
         # 2 - failed login due to password too short
         # or too long(should be between 8 - 80)
         self.login(username, password)
-        text1 = 'Field must be between 8 and 80 characters long.'
-        alert_info = self.driver.\
-            find_element(By.XPATH, "//*[text()=\"" + text1 + "\"]").text
+        #text1 = 'Field must be between 8 and 80 characters long.'
+        # alert_info = self.driver.\
+        #find_element(By.XPATH, "//*[text()=\"" + text1 + "\"]").text
+        # LogIn.close(self)
+        alert_info = self.driver.find_element(
+            By.ID, "password").get_attribute("validationMessage")
         LogIn.close(self)
         return alert_info
 
@@ -64,15 +70,16 @@ class LogIn:
         # 3 - failed login due to invalid email (no @),
         # Also with error - password too short
         self.login(username, password)
-        text1 = 'Invalid email'
-        text2 = 'Field must be between 8 and 80 characters long.'
+        # this is faulty. you cant get the 'invalid email'
+        # message is the password isn't the correct length
+        # . This test should only be testing for incorrect email
+        # , not password length
 
         alert1 = self.driver.\
-            find_element(By.XPATH, "//*[text()=\"" + text1 + "\"]").text
-        alert2 = self.driver.\
-            find_element(By.XPATH, "//*[text()=\"" + text2 + "\"]").text
+            find_element(
+                By.XPATH, "/html/body/div[2]/form/div[2]/div[1]/p").text
         LogIn.close(self)
-        return (alert1, alert2)
+        return (alert1)
 
     def get_incorrect_password_alert(self, username, password):
         # 4 - failed login due to incorrect password

--- a/tests/loginDriver.py
+++ b/tests/loginDriver.py
@@ -2,7 +2,6 @@ from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.by import By
-from signUpDriver import SignUp
 import time
 
 

--- a/tests/test1_login_test.py
+++ b/tests/test1_login_test.py
@@ -27,7 +27,7 @@ class Configure:
         return conf
 
     def _test_2_3_login_failure_by_invalid_email():
-        (username, password) = ("Wronginput.gmail.com", "a"*7)
+        (username, password) = ("Wronginput.gmail.com", "a"*8)
         conf = ConfigureUsernamePassword()
         conf.username = username
         conf.password = password
@@ -94,8 +94,10 @@ class TestLogin(unittest.TestCase):
         (username, password) = (conf.username, conf.password)
         alert_info = log_in_page.get_password_alert(username, password)
 
-        text = "Field must be between 8 and 80 characters long."
-        is_alert = alert_info == text
+        text = ""
+        for i in range(0, 15):  # get first two words of Constraint validation
+            text += alert_info[i]
+        is_alert = text == "Please lengthen"
 
         self.assertTrue(is_alert)
 
@@ -107,13 +109,12 @@ class TestLogin(unittest.TestCase):
         conf = \
             Configure._test_2_3_login_failure_by_invalid_email()
         (username, password) = (conf.username, conf.password)
-        (alert1, alert2) = log_in_page.\
+        (alert1) = log_in_page.\
             get_invalid_email_alert(username, password)
 
         is_alert1 = alert1 == "Invalid email"
-        is_alert2 = alert2 == "Field must be between 8 and 80 characters long."
 
-        self.assertTrue(is_alert1 and is_alert2)
+        self.assertTrue(is_alert1)
 
     def test_2_4_login_failure_by_incorrect_password(self):
         # failed login due to incorrect password


### PR DESCRIPTION
get_invalid_email_alert was looking for 'invalid email' message and password too short message. 'Invalid Email' would never show if password entered is too short. The password length was adjusted in the login method used so that the get_password_alert method is doing what is should: check for invalid email. Additionally, get_password_alert was using the incorrect Selenium locator to find error: this has been corrected. All tests currently pass with no errors.