### PR TITLE
Skil 126 - fixed checkboxes not working on new add course page

### DIFF
--- a/FrontEndReact/src/View/Admin/Add/AddCourse/AdminAddCourse.js
+++ b/FrontEndReact/src/View/Admin/Add/AddCourse/AdminAddCourse.js
@@ -75,6 +75,14 @@ class AdminAddCourse extends Component {
           },
         });
     };
+
+    handleCheckboxChange = (e) => {
+        const { id } = e.target;
+        this.setState({
+          [id]: e.target.checked,
+        });
+    };
+    
     
     handleSubmit = () => {
         const {
@@ -197,6 +205,8 @@ class AdminAddCourse extends Component {
         var state = navbar.state;
         var addCourse = state.addCourse;
         var confirmCreateResource = navbar.confirmCreateResource;
+
+        console.log(active, use_tas, use_fixed_teams)
         
         return (
             <React.Fragment>
@@ -283,6 +293,7 @@ class AdminAddCourse extends Component {
                                             <Checkbox
                                                 id="active"
                                                 checked={active}
+                                                onClick={this.handleCheckboxChange}
                                             />
                                         }
                                         name="newActive"
@@ -293,6 +304,7 @@ class AdminAddCourse extends Component {
                                             <Checkbox
                                                 id="use_tas"
                                                 checked={use_tas}
+                                                onClick={this.handleCheckboxChange}
                                             />
                                         }
                                         name="newUseTas"
@@ -301,8 +313,9 @@ class AdminAddCourse extends Component {
                                     <FormControlLabel
                                         control={
                                             <Checkbox
-                                                id="useFixedTeams"
+                                                id="use_fixed_teams"
                                                 checked={use_fixed_teams}
+                                                onClick={this.handleCheckboxChange}
                                             />
                                         }
                                         name="newFixedTeams"


### PR DESCRIPTION
Fixes an issue where checkboxes were not correctly working on the newly redesigned Add/Edit course page. 