### PR TITLE
Skil 385

### DIFF
--- a/FrontEndReact/src/__tests__/utility.test.js
+++ b/FrontEndReact/src/__tests__/utility.test.js
@@ -1,0 +1,13 @@
+import { getDueDateString } from "../utility.js";
+
+test("utility.test.js Test 1: Verify getDueDateString output is correct", () => {
+	// Test some dates
+	expect(getDueDateString(new Date(2024, 7, 12, 6, 32, 10, 354))).toBe("2024-8-12T6:32:10.354Z");
+	expect(getDueDateString(new Date(2001, 0, 1, 0, 0, 1, 999))).toBe("2001-1-1T0:0:1.999Z");
+	expect(getDueDateString(new Date(100, 11, 30, 23, 59, 59, 0))).toBe("100-12-30T23:59:59.0Z");
+	
+	// Test all days in a month
+	for (let d = 1; d <= 31; d++) {
+		expect(getDueDateString(new Date(2024, 7, d, 2, 0, 0, 999))).toBe(`2024-8-${d}T2:0:0.999Z`);
+	}
+});

--- a/FrontEndReact/src/__tests__/utility.test.js
+++ b/FrontEndReact/src/__tests__/utility.test.js
@@ -3,7 +3,9 @@ import { getDueDateString } from "../utility.js";
 test("utility.test.js Test 1: Verify getDueDateString output is correct", () => {
 	// Test some dates
 	expect(getDueDateString(new Date(2024, 7, 12, 6, 32, 10, 354))).toBe("2024-8-12T6:32:10.354Z");
+	
 	expect(getDueDateString(new Date(2001, 0, 1, 0, 0, 1, 999))).toBe("2001-1-1T0:0:1.999Z");
+	
 	expect(getDueDateString(new Date(100, 11, 30, 23, 59, 59, 0))).toBe("100-12-30T23:59:59.0Z");
 	
 	// Test all days in a month

--- a/FrontEndReact/src/utility.js
+++ b/FrontEndReact/src/utility.js
@@ -230,7 +230,7 @@ export function getDueDateString(dueDate) {
 
     let month = dueDate.getMonth() + 1;
 
-    let day = dueDate.getDay();
+    let day = dueDate.getDate();
 
     let hours = dueDate.getHours();
 


### PR DESCRIPTION
TODOs Completed:
- Fixed SKIL-385. The issue was that `getDueDateString` was using [`Date.getDay`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay) to get the day of the month, but `Date.getDay` actually returns the day of the week. I changed the call to [`Date.getDate`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate), which returns the day of the month.
- Also added a test that verifies that `getDueDateString` produces correct output.
