### PR TITLE
SKIL-434

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ for analysis.
   on important ports, run the following and expect
   no output:
 
-      lsof -i :3000,5000,6379
+      lsof -i :3000,5050,6379
   
   If output, there is a chance you still have processes
   running and you need to use the following command to

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile.backend
     ports:
-      - "127.0.0.1:5000:5000"
+      - "127.0.0.1:5050:5000"
     depends_on:
       - redis
     networks:
@@ -26,7 +26,7 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
     environment:
-      - REACT_APP_API_URL=http://localhost:5000/api
+      - REACT_APP_API_URL=http://localhost:5050/api
     networks:
       - app-network
 

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile.backend
     ports:
-      - "5000:5000"
+      - "127.0.0.1:5000:5000"
     depends_on:
       - redis
     networks:
@@ -15,7 +15,7 @@ services:
   redis:
     image: redis:7.2.4
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     networks:
       - app-network
 
@@ -24,7 +24,7 @@ services:
       context: .
       dockerfile: Dockerfile.frontend
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       - REACT_APP_API_URL=http://localhost:5000/api
     networks:


### PR DESCRIPTION
TODOs Completed:
- Currently all the ports defined in the Docker compose config are exposed on all interfaces, possibly overriding the host's firewall in the process. This PR changes it to only expose the ports on localhost, preventing anyone else on your local network from accessing your development environment.
- This PR also changes the backend port to 5050 instead of 5000, which fixes an issue where the macOS Control Center process has port 5000 bound.
