### PR TITLE
SKIL-432

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# OS
+**/*.DS_Store
+**/Thumbs.db
+
+# IDE
+**/.vscode
+**/*.idea
+**/*.iml
+
+# Backend
+**/__pycache__
+BackEndFlask/BackEndFlaskVenv
+
+# Frontend
+FrontEndReact/node_modules


### PR DESCRIPTION
TODOs Completed:
- Added a `.dockerignore` file that excludes the backend's Python virtual env and frontend's `node_modules` from being copied into the Docker containers when building. The Python virtual env is completely unused in the Docker container as all the packages are directly installed into the container's root pip packages, while the frontend container will run `npm install` as part of the build so copying over `node_modules` is unneeded.
- This change decreases the backend's image size by 250MB, and decreases the frontend's image size by 1.4GB.

Size Before:
```
REPOSITORY            TAG            IMAGE ID       CREATED          SIZE
rubricapp-backend     latest         beadd9976bb3   8 minutes ago    775MB
rubricapp-frontend    latest         6cf98d08fd91   10 minutes ago   3.93GB
```
Size After:
```
REPOSITORY            TAG            IMAGE ID       CREATED          SIZE
rubricapp-backend     latest         e293a86606f6   10 seconds ago   521MB
rubricapp-frontend    latest         cded14ef1ad9   2 minutes ago    2.49GB
```