### PR TITLE
SKIL-461

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -36,6 +36,9 @@ services:
       # Mount the source files inside the container to allow for React hot reloading to work
       - "./FrontEndReact/src:/app/src:ro"
       - "./FrontEndReact/public:/app/public:ro"
+      # Store React build cache in a volume to allow it to persist between container builds
+      # This improves startup time
+      - "frontend-cache:/app/node_modules/.cache"
     environment:
       - REACT_APP_API_URL=http://localhost:5050/api
     networks:
@@ -44,3 +47,6 @@ services:
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  frontend-cache:


### PR DESCRIPTION
TODOs Completed:
- The React build cache is now stored in a volume to allow it to persist between container builds.
- This improves the startup time of the frontend container after rebuilding the container with `docker compose build`. Previously it could take 30+ seconds for the frontend container to startup after rebuilding it, now it only takes 5-10 seconds.
