### PR TITLE
SKIL-483

### DIFF
--- a/FrontEndReact/src/View/Admin/View/CompleteAssessmentTask/Form.js
+++ b/FrontEndReact/src/View/Admin/View/CompleteAssessmentTask/Form.js
@@ -162,18 +162,18 @@ class Form extends Component {
 
             var category = unit[categoryName];
 
-                var observableCharacteristic = category["observable_characteristics"].includes("1");
+            var observableCharacteristic = category["observable_characteristics"].includes("1");
 
             const showSuggestions = this.props.navbar.state.chosenAssessmentTask["show_suggestions"];
             const suggestions = showSuggestions ? category["suggestions"].includes("1") : false;
 
-            var status = false;
+            let status = null; // null is for not filled out at all (grey empty circle on category tab)
 
             if (observableCharacteristic && (!showSuggestions || suggestions)) {
-                status = true;
+                status = true; // true is for fully filled out (green filled in circle on category tab)
 
             } else if (observableCharacteristic || suggestions) {
-                status = false;
+                status = false; // false is for partially filled out (yellow half filled in circle on category tab)
             }
 
             return status;


### PR DESCRIPTION
TODOs Completed:
- Fix the icons in the category tabs on the AT screen not being grey when the category isn't filled out at all.
- Add comments explaining why the return value of the function is `null`, `true`, or `false`.

<img width="363" alt="Screenshot 2024-10-03 at 9 29 35 PM" src="https://github.com/user-attachments/assets/0a4e8476-e539-4c65-adca-cf9f63941366">
