### PR TITLE
SKIL-477

### DIFF
--- a/FrontEndReact/src/View/Admin/View/ViewTeams/AdminViewTeams.js
+++ b/FrontEndReact/src/View/Admin/View/ViewTeams/AdminViewTeams.js
@@ -14,7 +14,6 @@ class AdminViewTeams extends Component {
         super(props);
 
         this.state = {
-            successMessage: this.props.navbar.state.successMessage,
             errorMessage: null,
             isLoaded: false,
             teams: null,
@@ -36,17 +35,6 @@ class AdminViewTeams extends Component {
         );
 
         genericResourceGET(url, "users", this);
-    }
-
-    componentDidUpdate() {
-        if (this.state.successMessage !== null) {
-            setTimeout(() => {
-                this.setState({
-                    successMessage: null
-                });
-                this.props.navbar.confirmCreateResource("Team");
-            }, 3000);
-        }
     }
 
     render() {
@@ -83,11 +71,10 @@ class AdminViewTeams extends Component {
         } else {
             return(
                 <Box>
-                    {this.state.successMessage !== null && 
+                    {navbar.state.successMessage !== null && 
                         <div className='container'>
                           <SuccessMessage 
-                            navbar={this.props.navbar}
-                            successMessage={this.state.successMessage}
+                            successMessage={navbar.state.successMessage}
                             aria-label="adminViewTeamsSuccessMessage"
                           />
                         </div>

--- a/FrontEndReact/src/View/Admin/View/ViewUsers/AdminViewUsers.js
+++ b/FrontEndReact/src/View/Admin/View/ViewUsers/AdminViewUsers.js
@@ -15,7 +15,6 @@ class AdminViewUsers extends Component {
         super(props);
 
         this.state = {
-            successMessage: this.props.navbar.state.successMessage,
             errorMessage: null,
             isLoaded: false,
             users: null,
@@ -38,17 +37,6 @@ class AdminViewUsers extends Component {
 
         genericResourceGET(
             "/role?", "roles", this);
-    }
-
-    componentDidUpdate() {
-        if (this.state.successMessage !== null) {
-            setTimeout(() => {
-                this.setState({
-                    successMessage: null
-                });
-                this.props.navbar.confirmCreateResource("User");
-            }, 3000);
-        }
     }
 
     render() {
@@ -87,11 +75,10 @@ class AdminViewUsers extends Component {
 
             return(
                 <Box>
-                    {this.state.successMessage !== null && 
+                    {state.successMessage !== null && 
                         <div className='container'>
                           <SuccessMessage 
-                            navbar={this.props.navbar}
-                            successMessage={this.state.successMessage}
+                            successMessage={state.successMessage}
                             aria-label="adminViewUsersSuccessMessage"
                           />
                         </div>

--- a/FrontEndReact/src/View/Navbar/AppState.js
+++ b/FrontEndReact/src/View/Navbar/AppState.js
@@ -65,6 +65,9 @@ class AppState extends Component {
             userConsent: null,
 
             addTeamAction: null,
+            
+            successMessage: null,
+            successMessageTimeout: undefined,
         }
 
         this.setNewTab = (newTab) => {
@@ -309,11 +312,14 @@ class AppState extends Component {
                 if (document.getElementsByClassName("alert-danger")[0] === undefined) {
                     if (resource === "User" || resource === "UserBulkUpload") {
                         this.setState({
-                            successMessage: resource === "UserBulkUpload" ? "The user bulk upload was successful!" : null,
                             activeTab: this.props.isSuperAdmin ? "SuperAdminUsers" : "Users",
                             user: null,
                             addUser: null
                         });
+                        
+                        if (resource === "UserBulkUpload") {
+                            this.setSuccessMessage("The user bulk upload was successful!");
+                        }
 
                     } else if (resource === "Course") {
                         this.setState({
@@ -336,11 +342,14 @@ class AppState extends Component {
 
                     } else if (resource === "Team" || resource === "TeamBulkUpload") {
                         this.setState({
-                            successMessage: resource === "TeamBulkUpload" ? "The team bulk upload was successful!" : null,
                             activeTab: "Teams",
                             team: null,
                             addTeam: true
                         });
+                        
+                        if (resource === "TeamBulkUpload") {
+                            this.setSuccessMessage("The team bulk upload was successful!");
+                        }
 
                     } else if (resource==="TeamMembers") {
                         this.setState({
@@ -382,6 +391,22 @@ class AppState extends Component {
                 }
             }
         }
+        
+        this.setSuccessMessage = (newSuccessMessage) => {
+            clearTimeout(this.state.successMessageTimeout);
+            
+            const timeoutId = setTimeout(() => {
+                this.setState({
+                    successMessage: null,
+                    successMessageTimeout: undefined,
+                });
+            }, 3000);
+            
+            this.setState({
+                successMessage: newSuccessMessage,
+                successMessageTimeout: timeoutId,
+            });
+        };
     }
 
     // The commented out code below saves the state of the Navbar,


### PR DESCRIPTION
TODOs Completed:
- Initialized `successMessage` to null in AppState to prevent empty success message from showing up on when viewing a course.
- Moved success message timeout to AppState instead of the team and user views. This prevents a tab transition from occurring even when you've switched away from the success message. Also fixes SKIL-476.
