### PR TITLE
SKIL-505

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -21,8 +21,8 @@ services:
 
   redis:
     image: redis:7.2.4
-    ports: [] # Disable exposed port so that Redis can run inside of the container and not be exposed to host machine -> If using [] for the redis stuff, keeping right beside "ports: " works because apparently implicit map keys need to be followed by map values (the implicit map key thing is the error I got if I tried to do a similar thing to the port binding comment below (I don't know why, but I think it's due to it being an empty list and thus needs to be right beside the ":"))
-    #- "127.0.0.1:6379:6379"
+    ports: [] # Disable exposed port so that Redis can run inside of the container and not be exposed to host machine.
+    #- "127.0.0.1:6379:6379" # Remove [] next to ports and uncomemnt this line to expose redis to the system again
     networks:
       - app-network
 

--- a/compose.yml
+++ b/compose.yml
@@ -21,9 +21,8 @@ services:
 
   redis:
     image: redis:7.2.4
-    ports: 
-    - "127.0.0.1:6379:6379"
-    #[] # Disable exposed port so that Redis can run inside of the container and not be exposed to host machine 
+    ports: [] # Disable exposed port so that Redis can run inside of the container and not be exposed to host machine -> If using [] for the redis stuff, keeping right beside "ports: " works because apparently implicit map keys need to be followed by map values (the implicit map key thing is the error I got if I tried to do a similar thing to the port binding comment below (I don't know why, but I think it's due to it being an empty list and thus needs to be right beside the ":"))
+    #- "127.0.0.1:6379:6379"
     networks:
       - app-network
 


### PR DESCRIPTION
TODOs Completed:
Update the Redis Port in the docker compose file since we only really need it when we are using docker. I added some comments on why I think it works, but I will also explain what I seen online, and on Reddit, and what Dr. Chat GPT and Claude explained. Basically, what I understood and how I think it works is by making it such that the port become private, but still accessible by everything else in the Docker network while making sure that it is not accessible to anything outside of the Docker network. Also, it apparently it improves the security of the system and makes it better for production use cases. Basically, by doing ports: [], there is no specific port mapping and thus the redis server is not exposed to the host machine. Furthermore, from what i understand, it prevents conflicts occurring with other services (which is what we were having initially with the docker stuff because there was the already binded redis port when using the virtual environment method and this new redis binding) and other instances of the Redis server being on (though I doubt we have multiple instances of Redis up unless some of us are working on multiple projects and each one of those projects require Redis). Now for the [] being right besides the ports: line, I don't know exactly why it needs to be this way other than it being similar to an empty list and thus redis needs to know that it can bind to a theoretically infinite number of ports rather than however many specific ports you have redis binded to.