### PR TITLE
SKIL-457

### DIFF
--- a/BackEndFlask/Functions/exportCsv.py
+++ b/BackEndFlask/Functions/exportCsv.py
@@ -30,6 +30,10 @@ def rounded_hours_difference(completed: datetime, seen: datetime) -> int:
     Return:
     Result: int (The lag_time between completed and seen)
     """
+
+    if seen is None:
+        return "" # If the feedback hasnt been viewed return an empty string for proper calculation
+        
     time_delta = seen - completed
 
     hours_remainder = divmod( divmod( time_delta.total_seconds(), 60 )[0], 60)
@@ -88,6 +92,8 @@ def create_csv(at_id: int) -> str:
         with io.StringIO() as csvFile:
             writer = csv.writer(csvFile, quoting=csv.QUOTE_MINIMAL)
 
+            completed_assessment_data = get_csv_data_by_at_id(at_id)
+
             # Next line is the header line and its values.
             writer.writerow(
                 ["Assessment_task_name"] +
@@ -97,6 +103,9 @@ def create_csv(at_id: int) -> str:
                 ["AT_completer_role (Admin[TA/Instructor] / Student)"] +
                 ["Notification_data"]
             )
+
+            if len(completed_assessment_data) == 0:
+                return csvFile.getvalue()
 
             completed_assessment_data = get_csv_data_by_at_id(at_id)
 
@@ -111,6 +120,26 @@ def create_csv(at_id: int) -> str:
                 [completed_assessment_data[0][Csv_data.AT_COMPLETER.value]] +
                 [completed_assessment_data[0][Csv_data.NOTIFICATION.value]]
             )
+
+            for entry in completed_assessment_data:
+                sfi_oc_data = get_csv_categories(entry[Csv_data.RUBRIC_ID.value])
+
+                lag = ""
+
+                try:
+                    lag = rounded_hours_difference(entry[Csv_data.COMP_DATE.value], entry[Csv_data.LAG_TIME.value])
+                except:
+                    pass
+
+                for i in entry[Csv_data.JSON.value]:
+                    if i == "comments" or i == "done":
+                        continue
+
+                    oc = entry[Csv_data.JSON.value][i]["observable_characteristics"]
+
+                    for j in range(0, len(oc)):
+                        if(oc[j] == '0'):
+                            continue
 
             # The block generates data lines.
             writer.writerow(

--- a/BackEndFlask/controller/Routes/Csv_routes.py
+++ b/BackEndFlask/controller/Routes/Csv_routes.py
@@ -38,11 +38,11 @@ def get_completed_assessment_csv() -> dict:
     try:
         assessment_task_id = request.args.get("assessment_task_id")
 
-        assessment = get_assessment_task(assessment_task_id)    # Trigger an error if not exists
+        assessment = get_assessment_task(assessment_task_id)    
 
         user_id = request.args.get("user_id")
 
-        user = get_user(user_id)   # Trigger an error if not exist
+        user = get_user(user_id)   
 
         file_name = user.first_name + "_"
 
@@ -50,9 +50,7 @@ def get_completed_assessment_csv() -> dict:
 
         file_name += assessment.assessment_task_name.replace(" ", "_") + ".csv"
 
-        csv_data = create_csv(
-            assessment_task_id
-        )
+        csv_data = create_csv(assessment_task_id)
         
         return create_good_response({ "csv_data": csv_data.strip() }, 200, "csv_creation")
 

--- a/BackEndFlask/controller/Routes/Csv_routes.py
+++ b/BackEndFlask/controller/Routes/Csv_routes.py
@@ -38,11 +38,11 @@ def get_completed_assessment_csv() -> dict:
     try:
         assessment_task_id = request.args.get("assessment_task_id")
 
-        assessment = get_assessment_task(assessment_task_id)    
+        assessment = get_assessment_task(assessment_task_id)    # Trigger an error if not exists    
 
         user_id = request.args.get("user_id")
 
-        user = get_user(user_id)   
+        user = get_user(user_id)   # Trigger an error if not exists   
 
         file_name = user.first_name + "_"
 

--- a/BackEndFlask/controller/Routes/Feedback_routes.py
+++ b/BackEndFlask/controller/Routes/Feedback_routes.py
@@ -11,7 +11,7 @@ def create_new_feedback():
 
         feedback_data["lag_time"] = None
 
-        feedback_data["feedback_time"] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+        feedback_data["feedback_time"] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
 
         feedback = create_feedback(request.json)
 

--- a/BackEndFlask/controller/Routes/Rating_routes.py
+++ b/BackEndFlask/controller/Routes/Rating_routes.py
@@ -61,9 +61,11 @@ def student_view_feedback():
             return create_bad_response(f"Feedback already exists", "feedbacks", 409)    
 
         feedback_data = request.json
-        feedback_data["feedback_time"] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-        feedback = create_feedback(request.json)
-
+        feedback_time = datetime.now()
+        feedback_data["feedback_time"] = feedback_time.strftime('%Y-%m-%dT%H:%M:%S')
+        
+        feedback = create_feedback(feedback_data)
+        
         return create_good_response(student_feedback_schema.dump(feedback), 200, "feedbacks")
     
     except Exception as e:

--- a/FrontEndReact/src/View/Student/View/AssessmentTask/ViewAssessmentTaskInstructions.js
+++ b/FrontEndReact/src/View/Student/View/AssessmentTask/ViewAssessmentTaskInstructions.js
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
 import 'bootstrap/dist/css/bootstrap.css';
 import Button from '@mui/material/Button';
+import {genericResourcePOST} from '../../../../utility.js';
+import Cookies from 'universal-cookie';  
 
 
 
@@ -14,9 +16,41 @@ class ViewAssessmentTaskInstructions extends Component {
     }
   }
 
-  handleContinueClick = () => {
+  handleContinueClick = async () => {
+    const navbar = this.props.navbar;
+    const state = navbar.state;
+    const cookies = new Cookies();
+    
+    try {
+        const userId = cookies.get('user')?.user_id;
+        if (!userId) {
+            console.error('User ID not found in cookies');
+            this.props.navbar.setNewTab("ViewStudentCompleteAssessmentTask");
+            return;
+        }
+
+        const completedAssessmentId = state.chosenCompleteAssessmentTask?.completed_assessment_id;
+        if (!completedAssessmentId) {
+            console.error('Completed assessment ID not found');
+            this.props.navbar.setNewTab("ViewStudentCompleteAssessmentTask");
+            return;
+        }
+
+        await genericResourcePOST(
+            '/feedback', 
+            this,
+            JSON.stringify({
+                user_id: userId,
+                completed_assessment_id: completedAssessmentId
+            })
+        );
+
+    } catch (error) {
+        console.error('Error recording feedback view:', error);
+    }
+
     this.props.navbar.setNewTab("ViewStudentCompleteAssessmentTask");
-  }
+}
 
   render() {
     var assessmentTaskName = this.props.navbar.state.chosenAssessmentTask.assessmentTaskName;


### PR DESCRIPTION
TODOS Completed:
Fix issue where feedback time lag was empty in exported CSV by:
- Add feedback viewing time recording via /feedback endpoint
- Fix datetime format mismatch in feedback recording
- Calculate time difference between completion and viewing time
- Return empty string for unviewed assessments
- Round lag time to nearest hour when viewed

Previously feedback time was not being recorded due to datetime format 
mismatch ('%Y-%m-%dT%H:%M:%S' vs '%Y-%m-%dT%H:%M:%S.%fZ'). Now correctly 
records and calculates time between assessment completion and student feedback viewing.
