### PR TITLE
SKIL-519

### DIFF
--- a/BackEndFlask/controller/Routes/User_routes.py
+++ b/BackEndFlask/controller/Routes/User_routes.py
@@ -333,7 +333,6 @@ class UserSchema(ma.Schema):
             'owner_id',
             'active',
             'has_set_password',
-            'reset_code',
             'is_admin',
             'role_id'
         )


### PR DESCRIPTION
TODOs Completed:
- Remove `reset_code` from users route response.
- Returning the hashed reset code is unneeded and a security risk.
