### PR TITLE
SKIL-485

### DIFF
--- a/BackEndFlask/models/assessment_task.py
+++ b/BackEndFlask/models/assessment_task.py
@@ -412,7 +412,7 @@ def replace_assessment_task(assessment_task, assessment_task_id):
 
     validate_number_of_teams(assessment_task["number_of_teams"])
     validate_max_team_size(assessment_task["max_team_size"])
-    
+
     one_assessment_task = AssessmentTask.query.filter_by(assessment_task_id=assessment_task_id).first()
 
     if one_assessment_task is None:

--- a/BackEndFlask/models/assessment_task.py
+++ b/BackEndFlask/models/assessment_task.py
@@ -2,6 +2,7 @@ from core import db
 from models.schemas import AssessmentTask, Team
 from datetime import datetime
 from models.utility import error_log
+from models.checkin import delete_checkins_over_team_count, delete_latest_checkins_over_team_size
 
 """
 Something to consider may be the due_date as the default
@@ -411,11 +412,19 @@ def replace_assessment_task(assessment_task, assessment_task_id):
 
     validate_number_of_teams(assessment_task["number_of_teams"])
     validate_max_team_size(assessment_task["max_team_size"])
-
+    
     one_assessment_task = AssessmentTask.query.filter_by(assessment_task_id=assessment_task_id).first()
 
     if one_assessment_task is None:
         raise InvalidAssessmentTaskID(assessment_task_id)
+
+    # Kick all members from ad hoc teams beyond new team count if there are now fewer teams
+    if one_assessment_task.number_of_teams > int(assessment_task["number_of_teams"]):
+        delete_checkins_over_team_count(assessment_task_id, int(assessment_task["number_of_teams"]))
+    
+    # Kick all members from ad hoc teams with too many members if there is now a smaller capacity
+    if one_assessment_task.max_team_size > int(assessment_task["max_team_size"]):
+        delete_latest_checkins_over_team_size(assessment_task_id, int(assessment_task["max_team_size"]))
 
     one_assessment_task.assessment_task_name = assessment_task["assessment_task_name"]
     one_assessment_task.course_id = assessment_task["course_id"]
@@ -431,7 +440,6 @@ def replace_assessment_task(assessment_task, assessment_task_id):
     one_assessment_task.number_of_teams = assessment_task["number_of_teams"]
     one_assessment_task.max_team_size = assessment_task["max_team_size"]
     
-
     db.session.commit()
 
     return one_assessment_task

--- a/BackEndFlask/models/assessment_task.py
+++ b/BackEndFlask/models/assessment_task.py
@@ -419,11 +419,11 @@ def replace_assessment_task(assessment_task, assessment_task_id):
         raise InvalidAssessmentTaskID(assessment_task_id)
 
     # Kick all members from ad hoc teams beyond new team count if there are now fewer teams
-    if one_assessment_task.number_of_teams > int(assessment_task["number_of_teams"]):
+    if assessment_task["number_of_teams"] is not None and one_assessment_task.number_of_teams > int(assessment_task["number_of_teams"]):
         delete_checkins_over_team_count(assessment_task_id, int(assessment_task["number_of_teams"]))
     
     # Kick all members from ad hoc teams with too many members if there is now a smaller capacity
-    if one_assessment_task.max_team_size > int(assessment_task["max_team_size"]):
+    if assessment_task["max_team_size"] is not None and one_assessment_task.max_team_size > int(assessment_task["max_team_size"]):
         delete_latest_checkins_over_team_size(assessment_task_id, int(assessment_task["max_team_size"]))
 
     one_assessment_task.assessment_task_name = assessment_task["assessment_task_name"]

--- a/BackEndFlask/models/checkin.py
+++ b/BackEndFlask/models/checkin.py
@@ -34,3 +34,43 @@ def get_checkins_by_assessment(assessment_task_id):
     checkins = Checkin.query.filter_by(assessment_task_id=assessment_task_id).all()
     
     return checkins
+
+# Generated with ChatGPT
+@error_log
+def delete_checkins_over_team_count(assessment_task_id, number_of_teams):
+    Checkin.query.filter(
+        Checkin.assessment_task_id == assessment_task_id,
+        Checkin.team_number > number_of_teams
+    ).delete()
+    
+    db.session.commit()
+
+# Generated with ChatGPT
+@error_log
+def delete_latest_checkins_over_team_size(assessment_task_id, max_team_size):
+    # Get all checkins for the assessment task
+    checkins = Checkin.query.filter_by(assessment_task_id=assessment_task_id).all()
+    
+    # Create a dictionary  to count checkins per team member
+    team_checkin_count = {}
+    
+    # Count the number of checkins for each team
+    for checkin in checkins:
+        if checkin.team_number in team_checkin_count:
+            team_checkin_count[checkin.team_number] += 1
+        else:
+            team_checkin_count[checkin.team_number] = 1
+            
+    # Loop through each team and remove checkins if they exceed max_team_size
+    for team_number, count in team_checkin_count.items():
+        while count > max_team_size:
+            # Find the latest checkin for this team
+            latest_checkin = Checkin.query.filter_by(assessment_task_id=assessment_task_id, team_number=team_number).order_by(Checkin.time.desc()).first()
+            
+            if latest_checkin:
+                db.session.delete(latest_checkin)
+                count -= 1
+            else:
+                break
+            
+    db.session.commit()


### PR DESCRIPTION
TODOs completed:
- Added some backend handling of updating ATs to remove adhoc checkin entries that exceed lowered max_team_size and number_of_teams to ATs
- checkins that exceed the new max_team_size for the AT are removed from latest to oldest
- checkins that exceed the new number_of_teams for the AT are removed in all cases

I was unable to test if the functionality works because I currently cannot access the student dashboard as a student. I have tested updating the ATs in both fixed and adhoc team mode, and I don't see any errors.