### PR TITLE
SKIL-532

### DIFF
--- a/FrontEndReact/src/View/Admin/View/ViewAssessmentTask/ViewAssessmentTasks.js
+++ b/FrontEndReact/src/View/Admin/View/ViewAssessmentTask/ViewAssessmentTasks.js
@@ -54,6 +54,7 @@ class ViewAssessmentTasks extends Component {
 
             const blob = new Blob([fileData], { type: 'csv' });
             const url = URL.createObjectURL(blob);
+            const exportAssessmentTask = document.getElementById(this.state.exportButtonId[assessmentName])
 
             const link = document.createElement("a");
             link.download = this.state.downloadedAssessment + ".csv";
@@ -62,9 +63,11 @@ class ViewAssessmentTasks extends Component {
             link.click();
 
             var assessmentName = this.state.downloadedAssessment;
-
+            
             setTimeout(() => {
-                document.getElementById(this.state.exportButtonId[assessmentName]).removeAttribute("disabled");
+                if(exportAssessmentTask) {
+                    exportAssessmentTask.removeAttribute("disabled");
+                }
             }, 10000);
 
             this.setState({

--- a/FrontEndReact/src/View/Admin/View/ViewAssessmentTask/ViewAssessmentTasks.js
+++ b/FrontEndReact/src/View/Admin/View/ViewAssessmentTask/ViewAssessmentTasks.js
@@ -54,13 +54,13 @@ class ViewAssessmentTasks extends Component {
 
             const blob = new Blob([fileData], { type: 'csv' });
             const url = URL.createObjectURL(blob);
-            
+
             const link = document.createElement("a");
             link.download = this.state.downloadedAssessment + ".csv";
             link.href = url;
             link.setAttribute('download', 'export.csv');
             link.click();
-            
+
             var assessmentName = this.state.downloadedAssessment;
             
             const exportAssessmentTask = document.getElementById(this.state.exportButtonId[assessmentName])

--- a/FrontEndReact/src/View/Admin/View/ViewAssessmentTask/ViewAssessmentTasks.js
+++ b/FrontEndReact/src/View/Admin/View/ViewAssessmentTask/ViewAssessmentTasks.js
@@ -54,15 +54,16 @@ class ViewAssessmentTasks extends Component {
 
             const blob = new Blob([fileData], { type: 'csv' });
             const url = URL.createObjectURL(blob);
-            const exportAssessmentTask = document.getElementById(this.state.exportButtonId[assessmentName])
-
+            
             const link = document.createElement("a");
             link.download = this.state.downloadedAssessment + ".csv";
             link.href = url;
             link.setAttribute('download', 'export.csv');
             link.click();
-
+            
             var assessmentName = this.state.downloadedAssessment;
+            
+            const exportAssessmentTask = document.getElementById(this.state.exportButtonId[assessmentName])
             
             setTimeout(() => {
                 if(exportAssessmentTask) {


### PR DESCRIPTION
TODOs Completed:
-Fixed the Crash with “document.getElementById(...) is null” as error by adding a condition to see if the element exists before we remove the attribute.