### PR TITLE
SKIL-559

### DIFF
--- a/BackEndFlask/controller/security/CustomDecorators.py
+++ b/BackEndFlask/controller/security/CustomDecorators.py
@@ -53,7 +53,7 @@ def verify_token(refresh: bool):
     if not id: raise InvalidQueryParamError("Missing user_id")
     token = request.headers.get('Authorization').split()[1]
     try:
-        decoded_id = decode_token(token)['sub'] if refresh else decode_token(token)['sub'][0]
+        decoded_id = int(decode_token(token)['sub'])
     except:
         raise NoAuthorizationError("No Authorization")
     id = to_int(id, "user_id")

--- a/BackEndFlask/controller/security/utility.py
+++ b/BackEndFlask/controller/security/utility.py
@@ -1,3 +1,4 @@
+import traceback
 from flask import request
 from core  import app
 from jwt   import ExpiredSignatureError
@@ -18,10 +19,10 @@ from flask_jwt_extended import (
 # jwt expires in 15mins; refresh token expires in 30days
 def create_tokens(user_i_d: any) -> 'tuple[str, str]':
     with app.app_context():
-        jwt = create_access_token([user_i_d])
+        jwt = create_access_token(str(user_i_d))
         refresh = request.args.get('refresh_token')
         if not refresh:
-            refresh = create_refresh_token(user_i_d)
+            refresh = create_refresh_token(str(user_i_d))
     return jwt, refresh
 
 # Takes away jwt and refresh tokens from response
@@ -52,8 +53,7 @@ def token_expired(thing: str) -> bool:
 # Function returns the user_id from the sub of the jwt
 def token_user_id(thing: str, refresh: bool = False) -> int:
     with app.app_context():
-        if refresh: return decode_token(thing)['sub']
-        return decode_token(thing)['sub'][0]
+        return int(decode_token(thing)['sub'])
 
 # Handles conversion issues and warns front end of problems
 def to_int(thing: str , subject: str) -> int:


### PR DESCRIPTION
TODOs Completed:
- Fixed auth issue causing infinite loading when logging in.
- This was caused by a recent update to [flask-jwt-extended](https://github.com/vimalloc/flask-jwt-extended). The JWT spec requires the `sub` parameter to be a string, however flask-jwt-extended was allowing it to be any JSON object. flask-jwt-extended pushed an [update (4.7.0)](https://github.com/vimalloc/flask-jwt-extended/releases/tag/4.7.0) yesterday that enforced the spec. This broke skillbuilder as the `sub` was an array instead of a string. More info: https://github.com/vimalloc/flask-jwt-extended/commit/f57ca909cbd8e7492c762986bca50f1a7c45a855
- This also seems to fix the issue with the CI.
