### PR TITLE
SKIL-560

### DIFF
--- a/FrontEndReact/src/View/Admin/View/Reporting/ViewAssessmentStatus/ViewAssessmentStatus.js
+++ b/FrontEndReact/src/View/Admin/View/Reporting/ViewAssessmentStatus/ViewAssessmentStatus.js
@@ -65,7 +65,7 @@ export default function ViewAssessmentStatus(props) {
   var allRatings = [];
   var avg = 0;
   var stdev = 0;
-  var progress = props.completedAssessmentsPercentage;
+  var progress = +props.completedAssessmentsPercentage.toFixed(2);
 
   if (props.completedAssessments !== null && props.completedAssessments.length > 0) {
     // Iterate through each completed assessment for chosen assessment task


### PR DESCRIPTION
Progress Bar should show only 2 decimal places max, and no extra trailing zeros if the number has less than 2 decimal places. This should fix the issue with 33.3333333%.