### PR TITLE
SKIL-580

### DIFF
--- a/BackEndFlask/Functions/teamBulkUpload.py
+++ b/BackEndFlask/Functions/teamBulkUpload.py
@@ -35,14 +35,14 @@ def __expect(lst: list[list[str]], cols: int | None = None) -> list[str]:
     will modify the original list passed.
     """
     hd: list[str] = lst.pop(0)
-    
+ 
     # Clean the row - specifically handle 'Unnamed:' columns and empty strings
     cleaned = []
     for x in hd:
         stripped = x.strip()
         if stripped and not stripped.startswith('Unnamed:'):
             cleaned.append(stripped)
-    
+
     if cols is not None and len(cleaned) != cols:
         raise TooManyColumns(1, cols, len(cleaned))
     return cleaned
@@ -71,7 +71,16 @@ def __parse(lst: list[list[str]]) -> list[TBUTeam]:
                     raise EmptyTeamName if team_name == "" else EmptyTAEmail
                 teams.append(TBUTeam(team_name, ta, students))
                 students = []
-                current_state = EXPECT_TA
+
+                multiple_observers = True
+                if len(lst) > 2:
+                    hd = __expect(lst)
+                    lookAhead = __expect(lst)
+                    lst.insert(0, lookAhead)
+                    lst.insert(0, hd)   
+                    multiple_observers = len(hd) == len(lookAhead) == 1
+
+                current_state = EXPECT_TA if multiple_observers else EXPECT_TEAM 
             continue
 
         # Process based on what type of row we're expecting


### PR DESCRIPTION
TODO:
-Allow the end user to be able to use only one observer when bulk uploading teams.