### PR TITLE
SKIL-592

### DIFF
--- a/FrontEndReact/src/View/Admin/View/Reporting/ViewAssessmentStatus/CharacteristicsAndImprovements.js
+++ b/FrontEndReact/src/View/Admin/View/Reporting/ViewAssessmentStatus/CharacteristicsAndImprovements.js
@@ -54,7 +54,7 @@ export default function CharacteristicsAndImprovements({
                 <u>{dataType === 'characteristics' ? 'Characteristics' : 'Improvements'}</u>
               </h6>
               
-              <div style={{ height: '210px' }}>
+              <div style={{ height: '250px' }}>
                 {shouldShowGraph ? (
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart


### PR DESCRIPTION
Temporary fix: Characteristics/Improvements should show up 9 to 12 categories on the y-axis. This fix is until I add a feature but for now it should not skip over values that should be there.