### PR TITLE
Skil 556

### DIFF
--- a/FrontEndReact/src/View/Components/AssessmentTaskDropdown.js
+++ b/FrontEndReact/src/View/Components/AssessmentTaskDropdown.js
@@ -5,14 +5,25 @@ import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 
 
-
 export default function AssessmentTaskDropdown(props) {
   var assessmentTaskList = [];
 
   props.assessmentTasks.map((assessmentTask) => {
+    // new code here
+
+    // This new code shortens the name of assessment task when it is displayed on the page
+    // this prevents the text from 'overflowing' and causing miss-alignment with other elements on the page.
+    // However this is a fixed size and thus cannot be altered, should a solution be made to automatically truncate the text?
+    // It also seems to affect the name in the drop-down menu, that might require fixing...
+    const truncatedName = assessmentTask["assessment_task_name"].length > 30 
+    ? assessmentTask["assessment_task_name"].substring(0, 30) + "..."
+    : assessmentTask["assessment_task_name"];
+
+    // {assessmentTask["assessment_task_name"]} was in place of {truncatedName}
+
     return assessmentTaskList.push(
       <MenuItem key={assessmentTask["assessment_task_id"]} value={assessmentTask["assessment_task_id"]}>
-        {assessmentTask["assessment_task_name"]}
+        {truncatedName}
       </MenuItem>
     );
   });

--- a/FrontEndReact/src/View/Components/AssessmentTaskDropdown.js
+++ b/FrontEndReact/src/View/Components/AssessmentTaskDropdown.js
@@ -13,12 +13,19 @@ export default function AssessmentTaskDropdown(props) {
     return assessmentTaskList.push(
       <MenuItem key={assessmentTask["assessment_task_id"]} value={assessmentTask["assessment_task_id"]}>
         {assessmentTask["assessment_task_name"]}
+        title={assessmentTask["assessment_task_name"]}
+        sx={{
+          maxWidth: '250px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap'
+        }}
       </MenuItem>
     );
   });
 
   return (
-    <FormControl sx={{ m: 3, minWidth: 300 }}>
+    <FormControl sx={{ m: 3, minWidth: 300, maxWidth: 300 }}>
       <InputLabel id="demo-simple-select-autowidth-label">Assessment Task</InputLabel>
 
       <Select
@@ -26,8 +33,16 @@ export default function AssessmentTaskDropdown(props) {
         id="demo-simple-select-autowidth"
         value={props.chosenAssessmentId}
         onChange={props.setChosenAssessmentId}
-        autoWidth
+        autoWidth={false}
         label="Assessment Task"
+        sx={{
+          '& .MuiSelect-select': {
+            maxWidth: '250px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }
+        }}
       >
         { assessmentTaskList }
       </Select>

--- a/FrontEndReact/src/View/Components/AssessmentTaskDropdown.js
+++ b/FrontEndReact/src/View/Components/AssessmentTaskDropdown.js
@@ -9,27 +9,39 @@ export default function AssessmentTaskDropdown(props) {
   var assessmentTaskList = [];
 
   props.assessmentTasks.map((assessmentTask) => {
-    // new code here
 
-    // This new code shortens the name of assessment task when it is displayed on the page
-    // this prevents the text from 'overflowing' and causing miss-alignment with other elements on the page.
-    // However this is a fixed size and thus cannot be altered, should a solution be made to automatically truncate the text?
-    // It also seems to affect the name in the drop-down menu, that might require fixing...
-    const truncatedName = assessmentTask["assessment_task_name"].length > 30 
-    ? assessmentTask["assessment_task_name"].substring(0, 30) + "..."
-    : assessmentTask["assessment_task_name"];
-
-    // {assessmentTask["assessment_task_name"]} was in place of {truncatedName}
+    const taskName = assessmentTask["assessment_task_name"];
 
     return assessmentTaskList.push(
-      <MenuItem key={assessmentTask["assessment_task_id"]} value={assessmentTask["assessment_task_id"]}>
-        {truncatedName}
+      <MenuItem
+          key = {assessmentTask["assessment_task_id"]}
+          value = {assessmentTask["assessment_task_id"]}
+          sx={{
+          // sx -> system extensions (writes css directly as Java Script).
+          // The code here handles the 'text overflow' when re-sizing the page and/or creating a very long
+          // assessment task name.
+          //
+          // The 'nowrap' prevents the text from wrapping around (more than 1 line of text)
+          // The 'ellipsis' ends the truncated text with ...
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          maxWidth: '100%'
+        }}
+      >
+        {taskName}
       </MenuItem>
     );
   });
 
   return (
-    <FormControl sx={{ m: 3, minWidth: 300 }}>
+    <FormControl 
+    // controlls the way the 'dropdown' is displayed.
+      sx={{ 
+        m: 3,           // margin
+        width: '95%'    // width
+      }}
+    >
       <InputLabel id="demo-simple-select-autowidth-label">Assessment Task</InputLabel>
 
       <Select
@@ -37,8 +49,16 @@ export default function AssessmentTaskDropdown(props) {
         id="demo-simple-select-autowidth"
         value={props.chosenAssessmentId}
         onChange={props.setChosenAssessmentId}
-        autoWidth
+        autoWidth={"false"}
         label="Assessment Task"
+        sx={{
+          // This handles the text overflow
+          '& .MuiSelect-select': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }
+        }}
       >
         { assessmentTaskList }
       </Select>

--- a/FrontEndReact/src/View/Components/AssessmentTaskDropdown.js
+++ b/FrontEndReact/src/View/Components/AssessmentTaskDropdown.js
@@ -13,19 +13,12 @@ export default function AssessmentTaskDropdown(props) {
     return assessmentTaskList.push(
       <MenuItem key={assessmentTask["assessment_task_id"]} value={assessmentTask["assessment_task_id"]}>
         {assessmentTask["assessment_task_name"]}
-        title={assessmentTask["assessment_task_name"]}
-        sx={{
-          maxWidth: '250px',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap'
-        }}
       </MenuItem>
     );
   });
 
   return (
-    <FormControl sx={{ m: 3, minWidth: 300, maxWidth: 300 }}>
+    <FormControl sx={{ m: 3, minWidth: 300 }}>
       <InputLabel id="demo-simple-select-autowidth-label">Assessment Task</InputLabel>
 
       <Select
@@ -33,16 +26,8 @@ export default function AssessmentTaskDropdown(props) {
         id="demo-simple-select-autowidth"
         value={props.chosenAssessmentId}
         onChange={props.setChosenAssessmentId}
-        autoWidth={false}
+        autoWidth
         label="Assessment Task"
-        sx={{
-          '& .MuiSelect-select': {
-            maxWidth: '250px',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap'
-          }
-        }}
       >
         { assessmentTaskList }
       </Select>

--- a/FrontEndReact/src/View/Components/CategoryDropdown.js
+++ b/FrontEndReact/src/View/Components/CategoryDropdown.js
@@ -11,14 +11,35 @@ export default function CategoryDropdown(props) {
 
   props.categories.map((category) => {
     return categoryList.push(
-      <MenuItem key={category} value={category}>
+      <MenuItem 
+        key={category} 
+        value={category}
+        sx={{
+          // sx -> system extensions (writes css directly as Java Script).
+          // The code here handles the 'text overflow' when re-sizing the page and/or creating a very long
+          // assessment task name.
+          //
+          // The 'nowrap' prevents the text from wrapping around (more than 1 line of text)
+          // The 'ellipsis' ends the truncated text with ...
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          maxWidth: '100%'
+        }}
+      >
         {category}
       </MenuItem>
     )
   });
 
   return (
-    <FormControl sx={{ m: 3, minWidth: 300 }}>
+    <FormControl 
+    // controlls the way the 'dropdown' is displayed.
+      sx={{ 
+        m: 3,           // margin
+        width: '95%'    // width
+      }}
+    >
         <InputLabel id="demo-simple-select-autowidth-label">Category</InputLabel>
 
         <Select
@@ -27,8 +48,16 @@ export default function CategoryDropdown(props) {
           value={props.chosenCategoryId}
           onChange={props.setChosenCategoryId}
           disabled={props.disabled}
-          autoWidth
+          autoWidth={"false"}
           label="Category"
+          sx={{
+          // This handles the text overflow
+          '& .MuiSelect-select': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }
+        }}
         >
           { categoryList }
         </Select>


### PR DESCRIPTION
Assessment task dropdowns and category dropdowns now stay within the container.
The text overflow issue has been resolved, as well as container scaling and overlap.

We have provided comments in the code explaining what has been done to solve the issue.

The paths to the modified files are below:

FrontEndReact > src > View > Components > AssessmentTaskDropdown.js

FrontEndReact > src > View > Components > CategoryDropdown.js