### PR TITLE
ModifyUbuntuMirrors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   setup_envs:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     outputs:
       mysql_user: ${{ steps.export-mysql.outputs.mysql_user }}
@@ -47,6 +48,7 @@ jobs:
           echo "mysql_database=$(grep MYSQL_DATABASE BackEndFlask/.env | cut -d '=' -f2)" >> $GITHUB_OUTPUT
 
   install_frontEnd_dependencies:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -65,6 +67,7 @@ jobs:
         run: npm ci
 
   install_backend_dependencies:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -85,6 +88,7 @@ jobs:
         run: pip install -r requirements.txt
 
   lint_frontend:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: install_frontEnd_dependencies
     steps: 
@@ -109,6 +113,7 @@ jobs:
         run: npx eslint --max-warnings=0 .
 
   tests:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs: [setup_envs, install_backend_dependencies, install_frontEnd_dependencies]
     strategy:
@@ -182,6 +187,21 @@ jobs:
         run: |
           echo -e '#!/bin/bash\necho "active"' | sudo tee /usr/bin/systemctl > /dev/null
           sudo chmod +x /usr/bin/systemctl
+
+      # Credit: https://github.com/JasonHonKL/Pardus-Browser/commit/9603e572d7ed34b3eda06b4e7ed23db483b7a20f
+      # Based on https://github.com/CrowdStrike/glide-core/pull/1113
+      - name: Change Mirror Priorities
+        runs:
+          using: "composite"
+          steps:
+            # https://github.com/actions/runner-images/issues/7048
+            - name: Change Mirror Priorities
+              shell: bash
+              run: |
+                sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
+                sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt
+                sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' /etc/apt/apt-mirrors.txt
+                sudo cat /etc/apt/apt-mirrors.txt
 
       - name: Install Redis server
         run: |
@@ -262,6 +282,7 @@ jobs:
           REACT_APP_API_URL: "http://127.0.0.1:5000/api"
 
   monitor_workflow:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs: [lint_frontend, tests]
     if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       # Credit: https://github.com/JasonHonKL/Pardus-Browser/commit/9603e572d7ed34b3eda06b4e7ed23db483b7a20f
       # Based on https://github.com/CrowdStrike/glide-core/pull/1113
       - name: Change Mirror Priorities
-        runs:
+        run:
           using: "composite"
           steps:
             # https://github.com/actions/runner-images/issues/7048

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,17 +191,12 @@ jobs:
       # Credit: https://github.com/JasonHonKL/Pardus-Browser/commit/9603e572d7ed34b3eda06b4e7ed23db483b7a20f
       # Based on https://github.com/CrowdStrike/glide-core/pull/1113
       - name: Change Mirror Priorities
-        run:
-          using: "composite"
-          steps:
-            # https://github.com/actions/runner-images/issues/7048
-            - name: Change Mirror Priorities
-              shell: bash
-              run: |
-                sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
-                sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt
-                sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' /etc/apt/apt-mirrors.txt
-                sudo cat /etc/apt/apt-mirrors.txt
+        shell: bash
+        run: |
+          sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
+          sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt
+          sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' /etc/apt/apt-mirrors.txt
+          sudo cat /etc/apt/apt-mirrors.txt
 
       - name: Install Redis server
         run: |


### PR DESCRIPTION
### Changes
- CI now has hard time stops to avoid running for too long
- CI is able to modify its mirror priorities to avoid being stuck downloading on the azure mirrors