### PR TITLE
fix teams error

### DIFF
--- a/BackEndFlask/Tests/integration/controller/test_user_routes.py
+++ b/BackEndFlask/Tests/integration/controller/test_user_routes.py
@@ -505,6 +505,44 @@ def test_get_all_team_members_with_course_and_user_ids(flask_app_mock, sample_to
                 print(f"Cleanup skipped: {e}")
 
 
+def test_get_all_team_members_with_unassigned_user(flask_app_mock, sample_token, auth_header, client):
+    with flask_app_mock.app_context():
+        cleanup_test_users(db.session)
+
+        try:
+            result = create_one_admin_course(False)
+            users = create_users(result["course_id"], result["user_id"], number_of_users=4)
+
+            team = sample_team(
+                team_name="Alpha",
+                observer_id=result["user_id"],
+                course_id=result["course_id"]
+            )
+            sample_team_user(team_id=team.team_id, user_id=users[0].user_id)
+            sample_team_user(team_id=team.team_id, user_id=users[1].user_id)
+
+            token = sample_token(user_id=users[2].user_id)
+
+            response = client.get(
+                f"/api/team_members?course_id={result['course_id']}&user_id={users[2].user_id}",
+                headers=auth_header(token)
+            )
+
+            data = response.get_json()
+            assert response.status_code == 404
+            assert data["message"] == "An error occurred: User is not assigned to a team in this course."
+
+        finally:
+            # Clean up
+            try:
+                TeamUser.query.delete()
+                delete_team(team.team_id)
+                delete_users(users)
+                delete_one_admin_course(result)
+            except Exception as e:
+                print(f"Cleanup skipped: {e}")
+
+
 def test_get_all_team_members_raises_exception(flask_app_mock, sample_token, auth_header, client):
     with flask_app_mock.app_context():
         cleanup_test_users(db.session)

--- a/BackEndFlask/Tests/integration/controller/test_user_routes.py
+++ b/BackEndFlask/Tests/integration/controller/test_user_routes.py
@@ -530,7 +530,7 @@ def test_get_all_team_members_with_unassigned_user(flask_app_mock, sample_token,
 
             data = response.get_json()
             assert response.status_code == 404
-            assert data["message"] == "An error occurred: User is not assigned to a team in this course."
+            assert data["message"] == "User is not assigned to a team in this course."
 
         finally:
             # Clean up

--- a/BackEndFlask/controller/Route_response.py
+++ b/BackEndFlask/controller/Route_response.py
@@ -53,6 +53,24 @@ def create_bad_response(msg: str, content_type: str, status: int|None = None) ->
     return response, response['status']
 
 
+def create_warning_response(msg: str, content_type: str, status: int) -> tuple[dict, int]:
+    response = __init_response()
+
+    JSON = {content_type: []}
+
+    response["status"] = status
+
+    response["success"] = False
+
+    response["message"] = msg
+
+    response["content"] = JSON
+
+    logger.warning(f"Warning response sent: user_id: {request.args.get('user_id')}, content type: {content_type}, msg: {msg}, status: {response['status']}, warning raised from function: {inspect.stack()[1][3]}")
+
+    return response, response["status"]
+
+
 def create_good_response(whole_json: list[dict], status: int, content_type: str, jwt=None, refresh=None) -> dict:
     """
     Description:

--- a/BackEndFlask/controller/Routes/User_routes.py
+++ b/BackEndFlask/controller/Routes/User_routes.py
@@ -189,7 +189,7 @@ def get_all_team_members():
             team_members, team_id = get_team_members(user_id, course_id)
 
             if team_id is None:
-                return create_bad_response(
+                return create_warning_response(
                     "User is not assigned to a team in this course.",
                     "team_members",
                     404,

--- a/BackEndFlask/controller/Routes/User_routes.py
+++ b/BackEndFlask/controller/Routes/User_routes.py
@@ -188,6 +188,13 @@ def get_all_team_members():
 
             team_members, team_id = get_team_members(user_id, course_id)
 
+            if team_id is None:
+                return create_bad_response(
+                    "User is not assigned to a team in this course.",
+                    "team_members",
+                    404,
+                )
+
             result = {}
 
             result["users"] = users_schema.dump(team_members)


### PR DESCRIPTION
Intended to fix errors found in all.log in production:
2026-07-14 17:09:58,676 - ERROR - /home/ubuntu/RUBRICAPP_PRODUCTION/rubricapp/BackEndFlask/models/utility.py 253 Error Type: InvalidTeamID Message: Invalid team_id: None.
2026-07-14 17:10:04,478 - ERROR - Bad response sent: user_id: 819, content type: team_members, msg: An error occurred retrieving team members: Invalid team_id: None., status: 400, error raised from function: get_all_team_members