### PR TITLE
updated last_updated field if user's email is changed

### DIFF
--- a/BackEndFlask/models/user.py
+++ b/BackEndFlask/models/user.py
@@ -387,6 +387,7 @@ def replace_user(user_data, user_id):
         raise InvalidUserID(user_id)
 
     if one_user.email != user_data["email"]:
+        one_user.last_update = datetime.now()
         spawn_thread(validate_pending_emails)
 
     one_user.first_name = user_data["first_name"]


### PR DESCRIPTION
replace_user updates the email (line 396) and even spawns the email validation thread (line 390) when the email changes, but never updates last_update. This is a bug.

When a user's email is changed, a new validation email goes out, but last_update still holds the original creation timestamp. The bounce-check window in threads.py will use that old timestamp, so if the new validation email bounces, the bounce detection may miss it entirely (the bounce event timestamp won't be within the expected window relative to last_update).

The fix is add one_user.last_update = datetime.now() in replace_user at line 396, right after the email is changed. 