### PR TITLE
Skil 795

### DIFF
--- a/FrontEndReact/src/View/Admin/View/ViewUsers/ViewUsers.tsx
+++ b/FrontEndReact/src/View/Admin/View/ViewUsers/ViewUsers.tsx
@@ -185,32 +185,30 @@ class ViewUsers extends Component<ViewUsersProps> {
  *   - Buttons are hidden if the userId matches the logged-in user and the user is an admin.
  * 
  */
-    if (!navbar.props.isSuperAdmin) {
-      columns.push({
-        name: "user_id",
-        label: "Edit",
-        options: {
-          filter: false,
-          setCellHeaderProps: () => { return { align: "center", width: "10%", className: "button-column-alignment" } },
-          setCellProps: () => { return { align: "center", width: "10%", className: "button-column-alignment" } },
-          customBodyRender: (userId: number) => {
-            var cookies = new Cookies();
-            return (
-              <IconButton id={"viewUsersEditButton" + userId}
-                size="small"
-                hidden={cookies.get('user')['user_id'] === userId && navbar.props.isAdmin}
-                onClick={() => {
-                  setAddUserTabWithUser(users, userId);
-                }}
-                aria-label="editUserButton"
-              >
-                <EditIcon sx={{ color: "black" }} />
-              </IconButton>
-            )
-          },
+    columns.push({
+      name: "user_id",
+      label: "Edit",
+      options: {
+        filter: false,
+        setCellHeaderProps: () => { return { align: "center", width: "10%", className: "button-column-alignment" } },
+        setCellProps: () => { return { align: "center", width: "10%", className: "button-column-alignment" } },
+        customBodyRender: (userId: number) => {
+          var cookies = new Cookies();
+          return (
+            <IconButton id={"viewUsersEditButton" + userId}
+              size="small"
+              hidden={cookies.get('user')['user_id'] === userId && navbar.props.isAdmin}
+              onClick={() => {
+                setAddUserTabWithUser(users, userId);
+              }}
+              aria-label="editUserButton"
+            >
+              <EditIcon sx={{ color: "black" }} />
+            </IconButton>
+          )
         },
-      } as any);
-    }
+      },
+    } as any);
     columns.push({
       name: "user_id",
       label: "Delete",

--- a/FrontEndReact/src/View/Admin/View/ViewUsers/__tests__/AdminViewUsers.test.tsx
+++ b/FrontEndReact/src/View/Admin/View/ViewUsers/__tests__/AdminViewUsers.test.tsx
@@ -24,7 +24,8 @@ var sbub = "studentBulkUploadButton";
 var abut = "adminBulkUploadTitle";
 var aub = "addUserButton";
 var auf = "addUserForm";
-test("NOTE: Tests 1-5 will not pass if Demo Data is not loaded!", () => {
+var sat = "superAdminTitle";
+test("NOTE: Tests 1-6 will not pass if Demo Data is not loaded!", () => {
     expect(true).toBe(true);
 });
 test("AdminViewUsers.test.tsx Test 1: should render Login Form component", () => {
@@ -108,5 +109,26 @@ test("AdminViewUsers.test.tsx Test 5: Should show Add User Form when clicking th
 
     await waitFor(() => {
         expectElementWithAriaLabelToBeInDocument(auf);
+    });
+});
+test("AdminViewUsers.test.tsx Test 6: Should show Edit User Form when clicking the Edit Icon for super admin view using super admin credentials (SKIL-795 regression)", async () => {
+    render(<Login />);
+
+    changeElementWithAriaLabelWithInput(ei, "superadminuser01@skillbuilder.edu");
+
+    changeElementWithAriaLabelWithInput(pi, globalThis.SUPER_ADMIN_PASSWORD);
+
+    clickElementWithAriaLabel(lb);
+
+    await waitFor(() => {
+        expectElementWithAriaLabelToBeInDocument(sat);
+    });
+
+    await waitFor(() => {
+        clickFirstElementWithAriaLabel(eub);
+    },{ timeout: 3000 });
+
+    await waitFor(() => {
+        expectElementWithAriaLabelToBeInDocument(eut);
     });
 });

--- a/FrontEndReact/src/View/Admin/View/ViewUsers/__tests__/AdminViewUsers.test.tsx
+++ b/FrontEndReact/src/View/Admin/View/ViewUsers/__tests__/AdminViewUsers.test.tsx
@@ -1,6 +1,7 @@
 import { test, expect } from "@jest/globals";
 import { render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import Cookies from "universal-cookie";
 import Login from "../../../../Login/Login";
 
 import {
@@ -112,7 +113,19 @@ test("AdminViewUsers.test.tsx Test 5: Should show Add User Form when clicking th
     });
 });
 test("AdminViewUsers.test.tsx Test 6: Should show Edit User Form when clicking the Edit Icon for super admin view using super admin credentials (SKIL-795 regression)", async () => {
+    // Previous tests logged in as the demo admin and never logged out, so their
+    // auth cookies are still present. Clear them so Login renders the form
+    // instead of auto-authenticating as the demo admin via checkAuthStatus().
+    const cookies = new Cookies();
+    cookies.remove('access_token');
+    cookies.remove('refresh_token');
+    cookies.remove('user');
+
     render(<Login />);
+
+    await waitFor(() => {
+        expectElementWithAriaLabelToBeInDocument(lf);
+    });
 
     changeElementWithAriaLabelWithInput(ei, "superadminuser01@skillbuilder.edu");
 


### PR DESCRIPTION
Super admins had no way to edit user data from the Users table — the edit icon never rendered for them. This restores it.