### PR TITLE
refactor: finish navbar role-cache cleanup and restore typechecking

### DIFF
--- a/FrontEndReact/package-lock.json
+++ b/FrontEndReact/package-lock.json
@@ -39,7 +39,7 @@
         "react-validation": "^3.0.7",
         "recharts": "^3.8.1",
         "ts-node": "^10.9.2",
-        "typescript": "4.9.5",
+        "typescript": "^5.6.3",
         "universal-cookie": "^7.2.2",
         "validator": "^13.12.0",
         "web-vitals": "^4.2.4"
@@ -3900,9 +3900,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3920,9 +3917,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3940,9 +3934,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3960,9 +3951,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3980,9 +3968,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4000,9 +3985,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5204,9 +5186,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5221,9 +5200,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5238,9 +5214,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5255,9 +5228,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5272,9 +5242,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5289,9 +5256,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5306,9 +5270,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5323,9 +5284,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5340,9 +5298,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5357,9 +5312,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14272,9 +14224,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14296,9 +14245,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14320,9 +14266,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14344,9 +14287,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16171,6 +16111,14 @@
         }
       }
     },
+    "node_modules/recharts/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -17588,16 +17536,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/FrontEndReact/package.json
+++ b/FrontEndReact/package.json
@@ -51,7 +51,7 @@
     "react-validation": "^3.0.7",
     "recharts": "^3.8.1",
     "ts-node": "^10.9.2",
-    "typescript": "4.9.5",
+    "typescript": "^5.6.3",
     "universal-cookie": "^7.2.2",
     "validator": "^13.12.0",
     "web-vitals": "^4.2.4"

--- a/FrontEndReact/src/View/Admin/Add/AddCourse/__tests__/AdminAddCourse.test.tsx
+++ b/FrontEndReact/src/View/Admin/Add/AddCourse/__tests__/AdminAddCourse.test.tsx
@@ -274,7 +274,10 @@ test("AdminAddCourse.test.tsx Test 10: Filling in valid input and clicking the A
         expectElementWithAriaLabelToBeInDocument(act);
     });
 
-    var courseName = "Comparative Programming Languages";
+    // The backend has no course-delete endpoint, so this test can't clean up
+    // after itself; a unique name per run keeps repeat runs from colliding
+    // with a course an earlier run already created.
+    var courseName = `Comparative Programming Languages ${Date.now()}`;
 
     changeElementWithAriaLabelWithInput(cnami, courseName);
 

--- a/FrontEndReact/src/View/Admin/Add/AddCustomRubric/AddCustomRubric.tsx
+++ b/FrontEndReact/src/View/Admin/Add/AddCustomRubric/AddCustomRubric.tsx
@@ -73,7 +73,7 @@ class AddCustomRubric extends React.Component<AddCustomRubricProps, AddCustomRub
         };
 
         this.handleCreateRubric = (pickedCategories: Category[]) => {
-            const rubricId = this.props.rubricId ?? navbar.state.selectedRubricId;
+            const rubricId = this.props.rubricId ?? this.props.navbar.state.selectedRubricId;
             const categoryIds: number[] = [];
             const rubricName = (document.getElementById("rubricNameInput") as HTMLInputElement)?.value || ""
             const rubricDescription = (document.getElementById("rubricDescriptionInput") as HTMLTextAreaElement)?.value || ""

--- a/FrontEndReact/src/View/Admin/Add/AddTask/__tests__/AdminAddAssessmentTask.test.tsx
+++ b/FrontEndReact/src/View/Admin/Add/AddTask/__tests__/AdminAddAssessmentTask.test.tsx
@@ -185,8 +185,11 @@ test("AdminAddAssessmentTask.test.tsx Test 5: Should return back to the Assessme
 
     clickElementWithAriaLabel(aatn);
 
+    // The backend has no assessment-task-delete endpoint, so this test can't
+    // clean up after itself; a unique name per run keeps repeat runs from
+    // colliding with a task an earlier run already created.
     await waitFor(() => {
-        changeElementWithAriaLabelWithInput(aatn, "Make a class");
+        changeElementWithAriaLabelWithInput(aatn, `Make a class ${Date.now()}`);
     });
 
     await waitFor(() => {

--- a/FrontEndReact/src/View/Admin/Add/AddTask/__tests__/AdminAddAssessmentTask.test.tsx
+++ b/FrontEndReact/src/View/Admin/Add/AddTask/__tests__/AdminAddAssessmentTask.test.tsx
@@ -187,9 +187,13 @@ test("AdminAddAssessmentTask.test.tsx Test 5: Should return back to the Assessme
 
     // The backend has no assessment-task-delete endpoint, so this test can't
     // clean up after itself; a unique name per run keeps repeat runs from
-    // colliding with a task an earlier run already created.
+    // colliding with a task an earlier run already created. Generated once
+    // here rather than inside waitFor, whose callback re-runs on retry and
+    // would otherwise type a different name each attempt.
+    var taskName = `Make a class ${Date.now()}`;
+
     await waitFor(() => {
-        changeElementWithAriaLabelWithInput(aatn, `Make a class ${Date.now()}`);
+        changeElementWithAriaLabelWithInput(aatn, taskName);
     });
 
     await waitFor(() => {

--- a/FrontEndReact/src/View/Admin/View/Reporting/ExportGraphComparison/GraphCard.tsx
+++ b/FrontEndReact/src/View/Admin/View/Reporting/ExportGraphComparison/GraphCard.tsx
@@ -32,6 +32,21 @@ interface GraphCardProps {
   onSelect: (graphId: string) => void;
 }
 
+/**
+ * Row shape for the horizontal bar charts. The characteristics and improvements
+ * graphs carry different source fields, so they are unified here into a single
+ * element type; without it chartData is a union of two array types and recharts
+ * infers its BarChart generic from only the first one.
+ * The charts themselves read only `label` and `percentage`.
+ */
+type GraphBarDatum = {
+  label: string;
+  number: number;
+  percentage: number;
+  characteristic?: string;
+  improvement?: string;
+};
+
 const GraphCard: React.FC<GraphCardProps> = ({ graphItem, isSelected, onSelect }) => {
   const cardRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
@@ -82,7 +97,7 @@ const GraphCard: React.FC<GraphCardProps> = ({ graphItem, isSelected, onSelect }
   }, [graphItem.assessment_task_name, graphItem.team_name, graphItem.student_name, graphItem.due_date, graphItem.total_assessments]);
 
   // Memoize data transformations for horizontal bar charts
-  const chartData = useMemo(() => {
+  const chartData = useMemo<GraphBarDatum[] | null>(() => {
     const { graph_type, graph_data } = graphItem;
     if (graph_type === 'characteristics' && 'characteristics' in graph_data) {
       return graph_data.characteristics.map((item) => ({

--- a/FrontEndReact/src/View/Admin/View/ViewAssessmentTask/AdminViewAssessmentTask.tsx
+++ b/FrontEndReact/src/View/Admin/View/ViewAssessmentTask/AdminViewAssessmentTask.tsx
@@ -40,7 +40,8 @@ class AdminViewAssessmentTask extends Component<AdminViewAssessmentTaskProps, Ad
     }
 
      //Fetches all necessary data when component first loads
-     //API 4 calls made: Fetches teams for the course, fetch assessment tasks for the course, fetch all system roles, fetch all rubrics
+     //API 3 calls made: fetch teams for the course, fetch assessment tasks for the course, fetch all rubrics
+     //Role names are not fetched here; they come from the navbar's cached navbar.state.roleNameMap
 
     componentDidMount() {
         //Extract data from props       
@@ -109,7 +110,7 @@ class AdminViewAssessmentTask extends Component<AdminViewAssessmentTaskProps, Ad
             //Shows while waiting for all API calls to complete
             //Checks ALL required data exists before proceeding
 
-        } else if (!isLoaded || !assessmentTasks || !rubrics || !teams || !navbar.state.roles || !navbar.state.roleNameMap) {
+        } else if (!isLoaded || !assessmentTasks || !rubrics || !teams || !navbar.state.roleNameMap) {
             return(
                 <Loading />
             )

--- a/FrontEndReact/src/View/Admin/View/ViewCompleteAssessmentTasks/AdminViewCompleteAssessmentTasks.tsx
+++ b/FrontEndReact/src/View/Admin/View/ViewCompleteAssessmentTasks/AdminViewCompleteAssessmentTasks.tsx
@@ -87,7 +87,7 @@ class AdminViewCompleteAssessmentTasks extends Component<
             );
         }
 
-        if (!isLoaded || !completedAssessments || !users || !navbar.state.roles || !navbar.state.roleNameMap) {
+        if (!isLoaded || !completedAssessments || !users || !navbar.state.roleNameMap) {
             return <Loading />;
         }
 

--- a/FrontEndReact/src/View/Admin/View/ViewUsers/AdminViewUsers.tsx
+++ b/FrontEndReact/src/View/Admin/View/ViewUsers/AdminViewUsers.tsx
@@ -19,7 +19,6 @@ import { User } from '../../../../types/User';
  * @property {string|null} state.errorMessage - The error message to display if an error occurs during data fetching.
  * @property {boolean} state.isLoaded - Indicates whether the data has been loaded.
  * @property {Array|null} state.users - The list of users in the course or system.
- * @property {Array|null} state.roles - The list of roles available in the system.
  * @property {number} state.prevUsersLength - The previous length of the users array for comparison.
  * @property {string|null} state.successMessage - The success message to display after successful operations.
  * 
@@ -155,7 +154,7 @@ class AdminViewUsers extends Component<AdminViewUsersProps, AdminViewUsersState>
                 </div>
             )
 
-        } else if (!isLoaded || !users || !state.roles || !state.roleNameMap) {
+        } else if (!isLoaded || !users || !state.roleNameMap) {
             return(
                 <Loading />
             )

--- a/FrontEndReact/src/View/Admin/View/ViewUsers/AdminViewUsers.tsx
+++ b/FrontEndReact/src/View/Admin/View/ViewUsers/AdminViewUsers.tsx
@@ -24,7 +24,7 @@ import { User } from '../../../../types/User';
  * 
  * Conditional Rendering:
  * - if navbar.state.user or navbar.state.addUser is set, renders AdminAddUser component.
- * - else, renders ViewUsers component with fetched users and roles.
+ * - else, renders ViewUsers component with fetched users and role names from navbar.state.roleNameMap.
  */
 
 interface AdminViewUsersProps {

--- a/FrontEndReact/src/View/Navbar/AppState.tsx
+++ b/FrontEndReact/src/View/Navbar/AppState.tsx
@@ -85,6 +85,8 @@ import { genericResourceGET, parseRoleNames } from '../../utility';
  * @property {string|null} state.jumpToSection - Used in Complete Assessment to auto-scroll to a specific section.
  *
  * @property {Object[]|null} state.roles - All roles in the system, fetched once via GET /role on mount (not scoped to a course).
+ *      Written by genericResourceGET itself (it assigns the response to the state key named by its `resource` argument),
+ *      not by the .then() below. Nothing currently reads it; consumers use state.roleNameMap instead.
  * @property {Object|null} state.roleNameMap - role_id -> role_name lookup derived from state.roles, exposed app-wide via navbar.state.roleNameMap.
  */
 
@@ -92,7 +94,9 @@ interface AppStateProps {
     isSuperAdmin?: boolean;
     isAdmin?: boolean;
     userName?: string;
-    logout?: () => void;
+    // Required: ButtonAppBar's logout is non-optional, and the only render site
+    // (Login) always supplies it.
+    logout: () => void;
 }
 
 interface AppStateState {
@@ -791,10 +795,11 @@ class AppState extends Component<AppStateProps, AppStateState> {
 
         // Fetch all roles once on mount so any screen can read role names
         // via navbar.state.roleNameMap without its own /role fetch.
+        // genericResourceGET already sets state.roles from the response, so only the
+        // derived lookup needs to be set here.
         genericResourceGET(`/role`, "roles", this).then(result => {
             if (result !== undefined && result["roles"] != null) {
                 this.setState({
-                    roles: result["roles"],
                     roleNameMap: parseRoleNames(result["roles"])
                 });
             }
@@ -999,7 +1004,6 @@ class AppState extends Component<AppStateProps, AppStateState> {
 
                         <StudentDashboard
                             navbar={this}
-                            chosenCourse={this.state.chosenCourse}
                         />
                     </Box>
                 }
@@ -1021,8 +1025,6 @@ class AppState extends Component<AppStateProps, AppStateState> {
                     <Box className="page-spacing">
                         <StudentTeamMembers
                             navbar={this}
-                            team={this.state.team}
-                            chosenCourse={this.state.chosenCourse}
                         />
 
                         <Button
@@ -1140,8 +1142,6 @@ class AppState extends Component<AppStateProps, AppStateState> {
 
                         <StudentConfirmCurrentTeam
                             navbar={this}
-                            students={this.state.users}
-                            chosenCourse={this.state.chosenCourse}
                         />
                     </Box>
                 }

--- a/FrontEndReact/src/View/Navbar/Navbar.tsx
+++ b/FrontEndReact/src/View/Navbar/Navbar.tsx
@@ -25,7 +25,7 @@ import Settings from '@mui/icons-material/Settings';
  * 
  * @function ButtonAppBar
  * @param {Object} props - The properties passed to this navigation component.
- * @param {string} [props.userName] - Optional. The name of the currently logged-in user, displayed in the
+ * @param {string | undefined} [props.userName] - Optional. The name of the currently logged-in user, displayed in the
  *  navigation bar. May be explicitly undefined: AppState passes through its own optional userName prop.
  * @param {function} props.setNewTab - A callback used for in-app navigation. Triggered when the user selects:
  *  - "My account"

--- a/FrontEndReact/src/View/Navbar/Navbar.tsx
+++ b/FrontEndReact/src/View/Navbar/Navbar.tsx
@@ -25,7 +25,8 @@ import Settings from '@mui/icons-material/Settings';
  * 
  * @function ButtonAppBar
  * @param {Object} props - The properties passed to this navigation component.
- * @param {string} props.userName - The name of the currently logged-in user, displayed in the navigation bar.
+ * @param {string} [props.userName] - Optional. The name of the currently logged-in user, displayed in the
+ *  navigation bar. May be explicitly undefined: AppState passes through its own optional userName prop.
  * @param {function} props.setNewTab - A callback used for in-app navigation. Triggered when the user selects:
  *  - "My account"
  *  - "Privacy Policy"

--- a/FrontEndReact/src/View/Navbar/Navbar.tsx
+++ b/FrontEndReact/src/View/Navbar/Navbar.tsx
@@ -36,7 +36,9 @@ import Settings from '@mui/icons-material/Settings';
  */
 
 interface ButtonAppBarProps {
-    userName?: string;
+    // `| undefined` is required under exactOptionalPropertyTypes: AppState passes
+    // this through from its own optional userName prop.
+    userName?: string | undefined;
     setNewTab: (tab: string) => void;
     logout: () => void;
 }


### PR DESCRIPTION
Follows up the switch to the navbar's cached role data:

- Drop the redundant `state.roles` term from the loading guards in AdminViewAssessmentTask, AdminViewUsers, and AdminViewCompleteAssessmentTasks. AppState initializes `roles` and `roleNameMap` to null together and assigns them in a single setState, so they are never independently null; `roleNameMap` is the one the components actually consume. The guards themselves must stay: AppState fetches /role asynchronously in componentDidMount, so the map is still absent for a window after the child screens mount.
- Remove the redundant explicit `roles:` assignment in AppState's /role callback; genericResourceGET already writes that state key itself. Document where the field comes from and that nothing currently reads it.
- Fix stale comments: AdminViewAssessmentTask makes 3 API calls, not 4, and AdminViewUsers documented a `state.roles` field no longer on its interface.

Restore typechecking, which had been broken repo-wide since the Vite migration: tsconfig.json targets TS 5 (moduleResolution "Bundler", vite/client types) while package.json still pinned the CRA-era typescript 4.9.5, so tsc failed on the config before reading any source. Bump typescript to ^5.6.3 and fix the 7 errors that surfaced:

- AddCustomRubric referenced a bare `navbar` inside handleCreateRubric, where it is not in scope. This was a latent ReferenceError on the path where the rubricId prop is null.
- AppState passed `chosenCourse`, `team`, and `students` to StudentDashboard, StudentTeamMembers, and StudentConfirmCurrentTeam, none of which declare or read them; they take this data from navbar.state. Removed at the call sites.
- AppState's `logout` prop was optional but ButtonAppBar requires it, and the only render site always supplies it. Making it required exposed that ButtonAppBar's `userName` needs `| undefined` under exactOptionalPropertyTypes.
- GraphCard's chartData was a union of two array types, so recharts inferred its BarChart generic from only the first. Unified into a single GraphBarDatum.

Also cherry-picks the unique-name-per-run fix for the two tests that create persistent data, since the backend exposes no delete endpoint for Course or AssessmentTask to clean up with.

tsc --noEmit now exits 0 and the build passes. AdminAddCourse Test 10 remains red for an unrelated, pre-existing reason: it assumes a newly created course renders on the first page of the course table, which only holds while a database has 10 or fewer active courses.