### PR TITLE
SKIL-802

### DIFF
--- a/FrontEndReact/src/SBStyles.css
+++ b/FrontEndReact/src/SBStyles.css
@@ -825,6 +825,15 @@ body.mode .app-container {
   min-width: 600px !important;
 }
 
+/* ...but don't force that min-width on real small-screen touch devices
+   (e.g. iPhone 12 Pro / XR) - there it just causes the table (and its
+   pagination footer) to overflow and get clipped instead of stacking. */
+@media (max-width: 599px) and (pointer: coarse) {
+  .MuiTable-root {
+    min-width: 0 !important;
+  }
+}
+
 .MuiTableContainer-root {
   overflow-x: auto !important;
 }

--- a/FrontEndReact/src/View/Components/CustomDataTable.tsx
+++ b/FrontEndReact/src/View/Components/CustomDataTable.tsx
@@ -97,6 +97,8 @@ const customTheme = createTheme({
           fontSize: "1rem",
           backgroundColor: "var(--table-toolbar)",
           color: "var(--table-text)",
+          width: "100%",
+          tableLayout: "fixed",
         },
       },
     },
@@ -224,7 +226,7 @@ MuiTablePagination: {
 );
 
 const CustomDataTable = ({ data, columns, options }: CustomDataTableProps) => {
-  const isMobile = useMediaQuery('(max-width:100%)');
+  const isMobile = useMediaQuery('(max-width:600px)');
   const defaultOptions = {
     rowStyle: { height: 4 },
     responsive: (isMobile ? "vertical" : "standard") as "vertical" | "standard",


### PR DESCRIPTION
fix: ensure custome data page numbers scale properly on mobile devices. Correct the mobile media query check (originally, 100% width). Remove the 600px min-width on the table for small-screen touch devices; this caused the table and its pagination footer to clip instead of stacking. After changes were applied, mobile devices display correctly scaled custom data page numbers(this change was specifically targeting the iPhone 12 and XR)